### PR TITLE
Update arrow key codes in zxc-arrows.json

### DIFF
--- a/zxc-arrows.json
+++ b/zxc-arrows.json
@@ -10,9 +10,9 @@
         { "id": "z", "type": 1, "z_level": 1, "code": 44, "mapping": [1, 1, 128, 128], "pos": [1, 132] },
         { "id": "x", "type": 1, "z_level": 1, "code": 45, "mapping": [132, 1, 128, 128], "pos": [132, 132] },
         { "id": "c", "type": 1, "z_level": 1, "code": 46, "mapping": [263, 1, 128, 128], "pos": [263, 132] },
-        { "id": "up", "type": 1, "z_level": 1, "code": 61000, "mapping": [394, 1, 128, 128], "pos": [656, 1] },
-        { "id": "down", "type": 1, "z_level": 1, "code": 61008, "mapping": [525, 1, 128, 128], "pos": [656, 132] },
-        { "id": "left", "type": 1, "z_level": 1, "code": 61003, "mapping": [656, 1, 128, 128], "pos": [525, 132] },
-        { "id": "right", "type": 1, "z_level": 1, "code": 61005, "mapping": [787, 1, 128, 128], "pos": [787, 132] }
+        { "id": "up", "type": 1, "z_level": 1, "code": 57416, "mapping": [394, 1, 128, 128], "pos": [656, 1] },
+        { "id": "down", "type": 1, "z_level": 1, "code": 57424, "mapping": [525, 1, 128, 128], "pos": [656, 132] },
+        { "id": "left", "type": 1, "z_level": 1, "code": 57419, "mapping": [656, 1, 128, 128], "pos": [525, 132] },
+        { "id": "right", "type": 1, "z_level": 1, "code": 57421, "mapping": [787, 1, 128, 128], "pos": [787, 132] }
     ]
 }


### PR DESCRIPTION
I found the arrow key codes starting with 61 referred to my numpad arrow keys.  I replaced the key codes to the numbers starting with 57, which reflected my standard arrow keys.

I found these key codes as hex numbers in the input-overlay project's file docs/cct/js/vc.js (https://github.com/univrsal/input-overlay/blob/7de649611a01f9fdd55dd0f74f296e242f14fc66/docs/cct/js/vc.js).